### PR TITLE
Add update_user functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,24 @@ $chatkit->create_user(
   )
 )
 ```
+
+## Updating a user
+
+To update a user you must provide an `id`. You can optionally provide a `name`, an `avatar_url (string)` and `custom_data (array)` but you must include one of those three.
+
+```php
+$chatkit->update_user("ham", "Hamilton Chapman")
+```
+
+Or with an `avatar_url` and `custom_data`:
+
+```php
+$chatkit->create_user(
+  "ham",
+  "Hamilton Chapman"
+  "http://cat.com/cat.jpg",
+  array(
+    "my_custom_key" => "some data"
+  )
+)
+```

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -187,6 +187,36 @@ class Chatkit
         return $response;
     }
 
+    public function update_user($id, $name = null, $avatar_url = null, $custom_data = null)
+    {
+        $body = array();
+
+        if (!is_null($name)) {
+            $body['name'] = $name;
+        }
+        if (!is_null($avatar_url)) {
+            $body['avatar_url'] = $avatar_url;
+        }
+        if (!is_null($custom_data)) {
+            $body['custom_data'] = $custom_data;
+        }
+
+        if (empty($body)) {
+            throw new ChatkitException('At least one of the following are required: name, avatar_url, or custom_data.');
+        }
+
+        $ch = $this->create_curl(
+            $this->api_settings,
+            "/users/" . $id,
+            $this->get_server_token(),
+            "POST",
+            $body
+        );
+
+        $response = $this->exec_curl($ch);
+        return $response;
+    }
+
     /**
      * Utility function used to create the curl object with common settings.
      */

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -209,7 +209,7 @@ class Chatkit
             $this->api_settings,
             "/users/" . $id,
             $this->get_server_token(),
-            "POST",
+            "PUT",
             $body
         );
 


### PR DESCRIPTION
This simply allows for users to be updated. If this is not accepted please consider making `create_curl(), get_server_token(), exec_curl()` protected so that the Chatkit class can be extended to add this functionality.

If accepted could you please cut a new tag at 0.1.2 as well.