### PR TITLE
Adding update_user() functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ $chatkit->create_user(
 
 ## Updating a user
 
-To create a user you must provide an `id`. You can optionally provide a `name (string)`, an `avatar_url (string)` and `custom_data (array)`. One of the three optional fields must be provided.
+To update a user you must provide an `id`. You can optionally provide a `name (string)`, an `avatar_url (string)` and `custom_data (array)`. One of the three optional fields must be provided.
 
 ```php
 $chatkit->update_user("ham", "Hamilton Chapman")
@@ -91,3 +91,12 @@ $chatkit->update_user(
   )
 )
 ```
+
+## Send a message
+
+To send a message you must provide a user `id`, a `room_id` and the `text`.
+
+```php
+$chatkit->send_message(1001, "This is a wonderful message.")
+```
+

--- a/README.md
+++ b/README.md
@@ -70,3 +70,24 @@ $chatkit->create_user(
   )
 )
 ```
+
+## Updating a user
+
+To create a user you must provide an `id`. You can optionally provide a `name (string)`, an `avatar_url (string)` and `custom_data (array)`. One of the three optional fields must be provided.
+
+```php
+$chatkit->update_user("ham", "Hamilton Chapman")
+```
+
+Or with an `avatar_url` and `custom_data`:
+
+```php
+$chatkit->update_user(
+  "ham",
+  "Hamilton Chapman"
+  "http://cat.com/cat.jpg",
+  array(
+    "my_custom_key" => "some data"
+  )
+)
+```

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -187,6 +187,41 @@ class Chatkit
         return $response;
     }
 
+    public function update_user($id, $name = null, $avatar_url = null, $custom_data = null)
+    {
+        $body = array();
+
+        if (!is_null($name)) {
+            $body['name'] = $name;
+        }
+        if (!is_null($avatar_url)) {
+            $body['avatar_url'] = $avatar_url;
+        }
+        if (!is_null($custom_data)) {
+            $body['custom_data'] = $custom_data;
+        }
+
+        if (empty($body)) {
+            throw new ChatkitException('At least one of the following are required: name, avatar_url, or custom_data.');
+        }
+
+        $token = $this->generate_token(array(
+            'user_id' => $id,
+            'su' => true
+        ));
+
+        $ch = $this->create_curl(
+            $this->api_settings,
+            "/users/" . $id,
+            $token,
+            "PUT",
+            $body
+        );
+
+        $response = $this->exec_curl($ch);
+        return $response;
+    }
+
     /**
      * Utility function used to create the curl object with common settings.
      */

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -222,6 +222,32 @@ class Chatkit
         return $response;
     }
 
+    public function send_message($id, $room_id, $text)
+    {
+        $body = array(
+            'text' => $text
+        );
+
+        if (empty($body['text'])) {
+            throw new ChatkitException('A message text is required.');
+        }
+
+        $token = $this->generate_token(array(
+            'user_id' => $id
+        ));
+
+        $ch = $this->create_curl(
+            $this->api_settings,
+            '/rooms/' . $room_id . '/messages',
+            $token,
+            'POST',
+            $body
+        );
+
+        $response = $this->exec_curl($ch);
+        return $response;
+    }
+
     /**
      * Utility function used to create the curl object with common settings.
      */


### PR DESCRIPTION
This allows for users to be updated. If this is not accepted please consider making `create_curl(), get_server_token(), exec_curl()` protected so that the Chatkit class can be extended to add this functionality.

If accepted could you please cut a new tag at 0.1.2 as well.