### PR TITLE
Improve the developer experience (mostly error and response handling)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ composer.lock
 phpunit.xml
 test/config.php
 vendor
+.idea/

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -2,6 +2,10 @@
 
 namespace Chatkit;
 
+use Chatkit\Exceptions\ChatkitException;
+use Chatkit\Exceptions\ConfigurationException;
+use Chatkit\Exceptions\ConnectionException;
+use Chatkit\Exceptions\MissingArgumentException;
 use \Firebase\JWT\JWT;
 
 class Chatkit
@@ -149,11 +153,11 @@ class Chatkit
     protected function checkCompatibility()
     {
         if (!extension_loaded('curl')) {
-            throw new ChatkitException('The Chatkit library requires the PHP cURL module. Please ensure it is installed');
+            throw new ConfigurationException('The Chatkit library requires the PHP cURL module. Please ensure it is installed');
         }
 
         if (!extension_loaded('json')) {
-            throw new ChatkitException('The Chatkit library requires the PHP JSON module. Please ensure it is installed');
+            throw new ConfigurationException('The Chatkit library requires the PHP JSON module. Please ensure it is installed');
         }
     }
 
@@ -200,7 +204,7 @@ class Chatkit
         }
 
         if (empty($body)) {
-            throw new ChatkitException('At least one of the following are required: name, avatar_url, or custom_data.');
+            throw new MissingArgumentException('At least one of the following are required: name, avatar_url, or custom_data.');
         }
 
         $token = $this->generateToken(array(
@@ -236,7 +240,7 @@ class Chatkit
     public function createRoom($user_id, array $options = [])
     {
         if (is_null($user_id)) {
-            throw new ChatkitException('You must provide the ID of the user that you wish to create the room');
+            throw new MissingArgumentException('You must provide the ID of the user that you wish to create the room');
         }
         $body = [];
 
@@ -270,7 +274,7 @@ class Chatkit
         );
 
         if (empty($body['text'])) {
-            throw new ChatkitException('A message text is required.');
+            throw new MissingArgumentException('A message text is required.');
         }
 
         $token = $this->generateToken(array(
@@ -344,7 +348,7 @@ class Chatkit
         }
 
         if ($this->ch === false) {
-            throw new ChatkitException('Could not initialise cURL!');
+            throw new ConfigurationException('Could not initialise cURL!');
         }
 
         $ch = $this->ch;
@@ -393,17 +397,21 @@ class Chatkit
      */
     protected function execCurl($ch)
     {
-        $response = array();
+        $response = json_decode(curl_exec($ch), true);
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
-        $response['body'] = curl_exec($ch);
-        $response['status'] = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        // inform the user of a connection failure
+        if ($status == 0 || $response === false) {
+            throw new ConnectionException(curl_error($ch));
+        }
 
-        if ($response['body'] === false || $response['status'] < 200 || 400 <= $response['status']) {
-            $this->log('ERROR: execCurl error: '.curl_error($ch));
+        // or an error response from Chatkit
+        if ($status >= 400) {
+            $this->log('ERROR: execCurl error: '.print_r($response, true));
+            throw (new ChatkitException($response['error_description'], $status))->setBody($response);
         }
 
         $this->log('INFO: execCurl response: '.print_r($response, true));
-
         return $response;
     }
 }

--- a/src/ChatkitException.php
+++ b/src/ChatkitException.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace Chatkit;
-
-use Exception;
-
-class ChatkitException extends Exception
-{
-}

--- a/src/Exceptions/ChatkitException.php
+++ b/src/Exceptions/ChatkitException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Chatkit\Exceptions;
+
+use Exception;
+
+class ChatkitException extends Exception
+{
+    /**
+     * The complete error response from Chatkit
+     * Contains error, error_description and error_uri
+     *
+     * @var array
+     */
+    protected $body;
+
+    public function __construct($message = "", $code = 0, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return array
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @param array $body
+     * @return $this
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+        return $this;
+    }
+}

--- a/src/Exceptions/ConfigurationException.php
+++ b/src/Exceptions/ConfigurationException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Chatkit\Exceptions;
+
+use Exception;
+
+class ConfigurationException extends Exception
+{
+}

--- a/src/Exceptions/ConnectionException.php
+++ b/src/Exceptions/ConnectionException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Chatkit\Exceptions;
+
+use Exception;
+
+class ConnectionException extends Exception
+{
+}

--- a/src/Exceptions/MissingArgumentException.php
+++ b/src/Exceptions/MissingArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Chatkit\Exceptions;
+
+use Exception;
+
+class MissingArgumentException extends Exception
+{
+}


### PR DESCRIPTION
1. Exceptions are now broken into categories - Configuration, Missing Arguments, Connection and unexpected responses from the Chatkit service. Makes it easier for the dev to identify their problem.
2. cURL connection failures (such as due to a missing SSL cert or no internet) are now handled differently from 4xx responses from Chatkit and reported accordingly
3. 4xx responses from Chatkit now throw an exception with the `error_description` (eg "User 'john.doe@test.com' already exists") as the message and the complete response as the body. Previously, they merely failed silently and were returned in the `$response['body']` as a JSON string.
4. Successful responses no longer include the status key; rather they return the actual Chatkit response (eg the created user) as an array.