### PR TITLE
Add getRoomMessages function

### DIFF
--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -330,6 +330,33 @@ class Chatkit
 
         return $this->execCurl($ch);
     }
+    
+    /**
+     * Get messages in a room
+     *
+     * @param array $options
+     *              [Available Options]
+     *              • room_id (string|required): Represents the ID of the user that you want to get the rooms for.
+     * @return array
+     * @throws ChatkitException or MissingArgumentException
+     */
+    public function getRoomMessages($options)
+    {
+        if (is_null($options['room_id'])) {
+            throw new MissingArgumentException('You must provide the ID of the room that you want to get the messages for');
+        }
+
+        $room_id = $options['room_id'];
+
+        $ch = $this->createCurl(
+            $this->api_settings,
+            "/rooms/$room_id/messages",
+            $this->getServerToken(['user_id' => 'noop']),
+            'GET'
+        );
+
+        return $this->execCurl($ch);
+    }
 
     public function sendMessage($options)
     {


### PR DESCRIPTION
### What?

Add getRoomMessages function

### Why?

Because it's possible with REST API but wasn't in the library

----

Similar to #19 - I get a "Missing token subject" without supplying a user id, but I can enter any random user id and it works. This would be a problem on the API side I guess?
