### PR TITLE
use stringy room IDs in examples and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To send a message you must provide a user `id`, a `room_id` and the `text`.
 ```php
 $chatkit->sendMessage([
   'sender_id' => 'sarah',
-  'room_id' => 1001,
+  'room_id' => '1001',
   'text' => 'This is a wonderful message.'
 ]);
 ```

--- a/examples/get_room_messages.php
+++ b/examples/get_room_messages.php
@@ -7,4 +7,4 @@ $chatkit = new Chatkit\Chatkit([
   'key' => 'your:key'
 ]);
 
-print_r($chatkit->getRoomMessages([ 'room_id' =>  123456 ]));
+print_r($chatkit->getRoomMessages([ 'room_id' =>  '123456' ]));

--- a/examples/send_message.php
+++ b/examples/send_message.php
@@ -9,6 +9,6 @@ $chatkit = new Chatkit\Chatkit([
 
 print_r($chatkit->sendMessage([
   'sender_id' => 'ham',
-  'room_id' => 123456,
+  'room_id' => '123456',
   'text' => 'Vivan is the best'
 ]));

--- a/examples/set_read_cursor.php
+++ b/examples/set_read_cursor.php
@@ -9,6 +9,6 @@ $chatkit = new Chatkit\Chatkit([
 
 print_r($chatkit->setReadCursor([
   'user_id' =>  'ham',
-  'room_id' =>  456789,
+  'room_id' =>  '456789',
   'position' =>  123,
 ]));


### PR DESCRIPTION
Looks like we already treat room_ids as strings everywhere but the examples!