### PR TITLE
V3 message attachment

### DIFF
--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -27,6 +27,7 @@ class Chatkit
 
     const GLOBAL_SCOPE = 'global';
     const ROOM_SCOPE = 'room';
+    const MAX_INLINE_CONTENT_BYTE_SIZE = 2000;
 
     /**
      *
@@ -645,6 +646,13 @@ class Chatkit
 
             if (!isset($part['content']) && !isset($part['url']) && !isset($part['file'])) {
                 throw new MissingArgumentException('Each part must define either file, content or url');
+            }
+
+            // 'upgrade' big inline contents to attachments
+            if (isset($part['content']) &&
+                strlen($part['content']) > self::MAX_INLINE_CONTENT_BYTE_SIZE) {
+                $part['file'] = $part['content'];
+                unset($part['content']);
             }
 
             if (isset($part['file'])) {

--- a/src/Exceptions/UploadException.php
+++ b/src/Exceptions/UploadException.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Chatkit\Exceptions;
+
+use Exception;
+
+class UploadException extends Exception
+{
+    /**
+     * The complete error response from AWS
+     * Contains error, error_description and error_uri
+     *
+     * @var array
+     */
+    protected $body;
+
+    public function __construct($message = "", $code = 0, $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return array
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @param array $body
+     * @return $this
+     */
+    public function setBody($body)
+    {
+        $this->body = $body;
+        return $this;
+    }
+}

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -961,6 +961,28 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
         $this->assertArrayHasKey('message_id', $send_msg_res['body']);
     }
 
+    public function testSendMultipartMessageShouldCreateAttachmentIfLargeInlinePartProvided()
+    {
+        $user_id = $this->makeUser();
+        $room_id = $this->makeRoom($user_id);
+
+        // inline messages bigger than 2000 bytes should be 'upgraded'
+        // to attachments
+        $text = str_repeat('a', 2001);
+
+        $parts = [ ['type' => 'binary/octet-stream',
+                    'content' => $text ]
+        ];
+
+        $send_msg_res = $this->chatkit->sendMultipartMessage([
+            'sender_id' => $user_id,
+            'room_id' => $room_id,
+            'parts' => $parts
+        ]);
+        $this->assertEquals($send_msg_res['status'], 201);
+        $this->assertArrayHasKey('message_id', $send_msg_res['body']);
+    }
+
     public function testSendMultipartMessageShouldReturnAResponsePayloadIfAttachmentsProvided()
     {
         $user_id = $this->makeUser();

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -961,6 +961,33 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
         $this->assertArrayHasKey('message_id', $send_msg_res['body']);
     }
 
+    public function testSendMultipartMessageShouldReturnAResponsePayloadIfAttachmentsProvided()
+    {
+        $user_id = $this->makeUser();
+        $room_id = $this->makeRoom($user_id);
+
+        $file = openssl_random_pseudo_bytes(100);
+        $file_name = 'a broken image';
+
+        $parts = [ ['type' => 'image/png',
+                    'file' => $file,
+                    'name' => $file_name,
+                    'customData' => [ 'some' =>
+                                      [ 'nested' => 'data',
+                                        'number' => 42
+                                      ] ],
+                    'origin' => 'http://example.com' ]
+        ];
+
+        $send_msg_res = $this->chatkit->sendMultipartMessage([
+            'sender_id' => $user_id,
+            'room_id' => $room_id,
+            'parts' => $parts
+        ]);
+        $this->assertEquals($send_msg_res['status'], 201);
+        $this->assertArrayHasKey('message_id', $send_msg_res['body']);
+    }
+
     public function testSendSimpleMessageShouldReturnAResponsePayloadIfARoomIDSenderIDAndTextAreProvided()
     {
         $user_id = $this->guidv4(openssl_random_pseudo_bytes(16));
@@ -1711,5 +1738,25 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
 
     protected function extractName($value) {
         return $value['name'];
+    }
+
+    protected function makeUser() {
+        $user_id = $this->guidv4(openssl_random_pseudo_bytes(16));
+        $user_res = $this->chatkit->createUser([
+            'id' => $user_id,
+            'name' => 'Ham'
+        ]);
+        $this->assertEquals($user_res['status'], 201);
+
+        return $user_id;
+    }
+
+    protected function makeRoom($creator) {
+        $room_res = $this->chatkit->createRoom([
+            'creator_id' => $creator,
+            'name' => 'my room'
+        ]);
+        $this->assertEquals($room_res['status'], 201);
+        return $room_res['body']['id'];
     }
 }


### PR DESCRIPTION
### What?

* Split the `createCurl` function in 2, to support arbitrary requests with the `createRawCurl` function
* Add support for file attachments, assuming files are `strings` (of arbitrary bytes)
* Add a few convenience functions for repetitive test setup

### Why?

* Needed for full v3 support

----

- [ ] CHANGELOG updated if relevant?
