### PR TITLE
Revert inline upgrade

### DIFF
--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -27,7 +27,6 @@ class Chatkit
 
     const GLOBAL_SCOPE = 'global';
     const ROOM_SCOPE = 'room';
-    const MAX_INLINE_CONTENT_BYTE_SIZE = 2000;
 
     /**
      *
@@ -646,13 +645,6 @@ class Chatkit
 
             if (!isset($part['content']) && !isset($part['url']) && !isset($part['file'])) {
                 throw new MissingArgumentException('Each part must define either file, content or url');
-            }
-
-            // 'upgrade' big inline contents to attachments
-            if (isset($part['content']) &&
-                strlen($part['content']) > self::MAX_INLINE_CONTENT_BYTE_SIZE) {
-                $part['file'] = $part['content'];
-                unset($part['content']);
             }
 
             if (isset($part['file'])) {

--- a/tests/v3/MessageTest.php
+++ b/tests/v3/MessageTest.php
@@ -51,28 +51,6 @@ class MessageTest extends \Base {
         ]);
     }
 
-    public function testSendMultipartMessageShouldCreateAttachmentIfLargeInlinePartProvided()
-    {
-        $user_id = $this->makeUser();
-        $room_id = $this->makeRoom($user_id);
-
-        // inline messages bigger than 2000 bytes should be 'upgraded'
-        // to attachments
-        $text = str_repeat('a', 2001);
-
-        $parts = [ ['type' => 'binary/octet-stream',
-                    'content' => $text ]
-        ];
-
-        $send_msg_res = $this->chatkit->sendMultipartMessage([
-            'sender_id' => $user_id,
-            'room_id' => $room_id,
-            'parts' => $parts
-        ]);
-        $this->assertEquals($send_msg_res['status'], 201);
-        $this->assertArrayHasKey('message_id', $send_msg_res['body']);
-    }
-
     public function testSendMultipartMessageShouldReturnAResponsePayloadIfAttachmentsProvided()
     {
         $user_id = $this->makeUser();


### PR DESCRIPTION
### What?

 * Removes the upgrade functionality for large inline messages

### Why?

* This seems to open up for new issues, not outweighing the convenience of this functionality

----

- [ ] CHANGELOG updated if relevant?
