### PR TITLE
Fix fetchMultipartMessages query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-php/compare/1.2.0...HEAD)
 
+### Fixed
+
+- `fetchMultipartMessages` now uses passed query params
+
 ## [1.2.0](https://github.com/pusher/chatkit-server-php/compare/1.1.0...1.2.0) - 2019-03-08
 
 ### Added

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -1140,6 +1140,7 @@ class Chatkit
                 $fields[$field_name] = $options[$field_name];
             }
         }
+        return $fields;
     }
 
     /**

--- a/tests/v3/MessageTest.php
+++ b/tests/v3/MessageTest.php
@@ -176,7 +176,7 @@ class MessageTest extends \Base {
         }
     }
 
-    public function testFetchMultipartMessagesShouldReturnAResponsePayloadIfARoomIDAndDirectionAreProvided()
+    public function testFetchMultipartMessagesShouldReturnAResponsePayloadIfARoomIDAndNewerDirectionAreProvided()
     {
         $user_id = $this->makeUser();
         $room_id = $this->makeRoom($user_id);
@@ -194,6 +194,26 @@ class MessageTest extends \Base {
         $this->assertEquals(count($messages), count($get_msg_res['body']));
         $this->assertEquals(array_values($messages)[0], $get_msg_res['body'][0]['parts'][0]['content']);
         $this->assertEquals(array_values($messages)[1], $get_msg_res['body'][1]['parts'][0]['content']);
+    }
+
+    public function testFetchMultipartMessagesShouldReturnAResponsePayloadIfARoomIDAndOlderDirectionAreProvided()
+    {
+        $user_id = $this->makeUser();
+        $room_id = $this->makeRoom($user_id);
+
+        $messages = $this->makeMessages($room_id, [ [$user_id => 'hi first'],
+                                                    [$user_id => 'hi last'],
+        ]);
+
+        $get_msg_res = $this->chatkit->fetchMultipartMessages([
+            'room_id' => $room_id,
+            'direction' => 'older',
+        ]);
+
+        $this->assertEquals(200, $get_msg_res['status']);
+        $this->assertEquals(count($messages), count($get_msg_res['body']));
+        $this->assertEquals(array_values($messages)[0], $get_msg_res['body'][1]['parts'][0]['content']);
+        $this->assertEquals(array_values($messages)[1], $get_msg_res['body'][0]['parts'][0]['content']);
     }
 
    public function testFetchMultipartMessagesShouldReturnAResponsePayloadIfAnAttachmentProvided()

--- a/tests/v3/MessageTest.php
+++ b/tests/v3/MessageTest.php
@@ -159,7 +159,7 @@ class MessageTest extends \Base {
         ]);
 
         $this->assertEquals(200, $get_msg_res['status']);
-        $this->assertEquals(count($messages), count($get_msg_res['body']));
+        $this->assertEquals(count($sliced_messages), count($get_msg_res['body']));
 
         $parts = [ $get_msg_res['body'][0]['parts'][0],
                    $get_msg_res['body'][1]['parts'][0] ];

--- a/tests/v3/MessageTest.php
+++ b/tests/v3/MessageTest.php
@@ -176,6 +176,26 @@ class MessageTest extends \Base {
         }
     }
 
+    public function testFetchMultipartMessagesShouldReturnAResponsePayloadIfARoomIDAndDirectionAreProvided()
+    {
+        $user_id = $this->makeUser();
+        $room_id = $this->makeRoom($user_id);
+
+        $messages = $this->makeMessages($room_id, [ [$user_id => 'hi first'],
+                                                    [$user_id => 'hi last'],
+        ]);
+
+        $get_msg_res = $this->chatkit->fetchMultipartMessages([
+            'room_id' => $room_id,
+            'direction' => 'newer',
+        ]);
+
+        $this->assertEquals(200, $get_msg_res['status']);
+        $this->assertEquals(count($messages), count($get_msg_res['body']));
+        $this->assertEquals(array_values($messages)[0], $get_msg_res['body'][0]['parts'][0]['content']);
+        $this->assertEquals(array_values($messages)[1], $get_msg_res['body'][1]['parts'][0]['content']);
+    }
+
    public function testFetchMultipartMessagesShouldReturnAResponsePayloadIfAnAttachmentProvided()
     {
         $user_id = $this->makeUser();


### PR DESCRIPTION
### What?
Fixed `fetchMultipartMessages` with query params.


### Why?
As the `getOptionalFields` method didn't return anything the api request didn't have any passed query params.


----

- [x] CHANGELOG updated if relevant?
