### PR TITLE
Add push_notification_title_override to createRoom and updateRoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-php/compare/1.5.0...HEAD)
 
+### Added
+
+-   Support for `push_notification_title_override` to `createRoom` and `updateRoom`
+
 ## [1.5.0](https://github.com/pusher/chatkit-server-ruby/compare/1.4.0...1.5.0) - 2019-07-04
 
 ### Added

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -436,7 +436,7 @@ class Chatkit
         if (isset($options['name'])) {
             $body['name'] = $options['name'];
         }
-        if (isset($options['push_notification_title_override'])) {
+        if (array_key_exists('push_notification_title_override', $options)) { // We want to accept null
             $body['push_notification_title_override'] = $options['push_notification_title_override'];
         }
         if (isset($options['custom_data'])) {

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -406,8 +406,11 @@ class Chatkit
         if (isset($options['user_ids'])) {
             $body['user_ids'] = $options['user_ids'];
         }
+        if (isset($options['push_notification_title_override'])) {
+            $body['push_notification_title_override'] = $options['push_notification_title_override'];
+        }
         if (isset($options['custom_data'])) {
-        	$body['custom_data'] = $options['custom_data'];
+            $body['custom_data'] = $options['custom_data'];
         }
 
         $token = $this->getServerToken([ 'user_id' => $options['creator_id'] ])['token'];
@@ -433,8 +436,11 @@ class Chatkit
         if (isset($options['name'])) {
             $body['name'] = $options['name'];
         }
+        if (isset($options['push_notification_title_override'])) {
+            $body['push_notification_title_override'] = $options['push_notification_title_override'];
+        }
         if (isset($options['custom_data'])) {
-        	$body['custom_data'] = $options['custom_data'];
+            $body['custom_data'] = $options['custom_data'];
         }
 
         $room_id = rawurlencode($options['id']);

--- a/tests/v5/RoomTest.php
+++ b/tests/v5/RoomTest.php
@@ -78,6 +78,25 @@ class RoomTest extends \Base {
         $this->assertEquals($room_res['body']['custom_data'], array('foo' => 'bar'));
     }
 
+    public function testCreateRoomShouldReturnAResponsePayloadIfACreatorIDNameAndPushNotificationTitleOverrideAreProvided() {
+        $user_id = $this->guidv4(openssl_random_pseudo_bytes(16));
+        $user_res = $this->chatkit->createUser([
+            'id' => $user_id,
+            'name' => 'Ham'
+        ]);
+        $this->assertEquals($user_res['status'], 201);
+
+        $room_res = $this->chatkit->createRoom([
+            'creator_id' => $user_id,
+            'name' => 'my room',
+            'push_notification_title_override' => 'something'
+        ]);
+        $this->assertEquals($room_res['status'], 201);
+        $this->assertArrayHasKey('id', $room_res['body']);
+        $this->assertEquals($room_res['body']['name'], 'my room');
+        $this->assertEquals($room_res['body']['push_notification_title_override'], 'something');
+    }
+
     public function testUpdateRoomShouldRaiseAnExceptionIfNoIDIsProvided()
     {
         $this->expectException(Chatkit\Exceptions\MissingArgumentException::class);
@@ -104,6 +123,7 @@ class RoomTest extends \Base {
             'id' => $room_res['body']['id'],
             'name' => 'new name',
             'private' => true,
+            'push_notification_title_override' => 'something',
             'custom_data' => array('foo' => 'baz')
         ]);
         $this->assertEquals($update_res['status'], 204);
@@ -115,7 +135,45 @@ class RoomTest extends \Base {
         $this->assertEquals($get_res['status'], 200);
         $this->assertEquals($get_res['body']['name'], 'new name');
         $this->assertEquals($get_res['body']['private'], true);
+        $this->assertEquals($get_res['body']['push_notification_title_override'], 'something');
         $this->assertEquals($get_res['body']['custom_data'], array('foo' => 'baz'));
+    }
+
+    public function testShouldBePossibleToSetPNTitleOverrideToNull()
+    {
+        $user_id = $this->guidv4(openssl_random_pseudo_bytes(16));
+        $user_res = $this->chatkit->createUser([
+            'id' => $user_id,
+            'name' => 'Ham'
+        ]);
+        $this->assertEquals($user_res['status'], 201);
+
+        $room_res = $this->chatkit->createRoom([
+            'creator_id' => $user_id,
+            'name' => 'my room',
+            'push_notification_title_override' => 'something'
+        ]);
+        $this->assertEquals($room_res['status'], 201);
+        $this->assertTrue(
+            array_key_exists('push_notification_title_override', $room_res['body']),
+            'Room should contain push_notification_title_override on creation'
+        );
+
+        $update_res = $this->chatkit->updateRoom([
+            'id' => $room_res['body']['id'],
+            'push_notification_title_override' => null,
+        ]);
+        $this->assertEquals($update_res['status'], 204);
+        $this->assertEquals($update_res['body'], null);
+
+        $get_res = $this->chatkit->getRoom([
+            'id' => $room_res['body']['id']
+        ]);
+        $this->assertEquals($get_res['status'], 200);
+        $this->assertFalse(
+            array_key_exists('push_notification_title_override', $get_res['body']),
+            'Room should NOT contain push_notification_title_override after update'
+        );
     }
 
     public function testDeleteRoomShouldRaiseAnExceptionIfNoIDIsProvided()


### PR DESCRIPTION
### What?
Adding support for push_notification_title_override to createRoom and updateRoom


### Why?
So that customers can use this property in their applications


----

- [ ] CHANGELOG updated if relevant?
