### PR TITLE
Ensure that the optionally set fields are returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/pusher/chatkit-server-php/compare/1.6.0...HEAD)
+## [Unreleased](https://github.com/pusher/chatkit-server-php/compare/1.6.1...HEAD)
+
+## [1.6.0](https://github.com/pusher/chatkit-server-ruby/compare/1.5.0...1.6.1) - 2019-09-06
+
+## Fixed
+
+- `getOptionalFields` now works as expected and returns optionally set values.
 
 ## [1.6.0](https://github.com/pusher/chatkit-server-ruby/compare/1.5.0...1.6.0) - 2019-07-30
 

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -1203,6 +1203,8 @@ class Chatkit
                 $fields[$field_name] = $options[$field_name];
             }
         }
+
+        return $fields;
     }
 
     /**

--- a/tests/v5/MessageTest.php
+++ b/tests/v5/MessageTest.php
@@ -159,7 +159,7 @@ class MessageTest extends \Base {
         ]);
 
         $this->assertEquals(200, $get_msg_res['status']);
-        $this->assertEquals(count($messages), count($get_msg_res['body']));
+        $this->assertEquals(count($get_msg_res['body']), 2);
 
         $parts = [ $get_msg_res['body'][0]['parts'][0],
                    $get_msg_res['body'][1]['parts'][0] ];


### PR DESCRIPTION
### What?

Actually return the map which contains optional fields in `getOptionalFields`.


### Why?

Previously the variable was not returned which meant that request options
were never actually being sent over the wire to the server

----

- [x] CHANGELOG updated if relevant?
