### PR TITLE
Fix incorrect JWT token expiry due to timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-php/compare/1.6.1...HEAD)
 
+### Fixed
+
+- `generateToken` now correctly sets the JWT token expiry on all cases
+
 ## [1.6.1](https://github.com/pusher/chatkit-server-ruby/compare/1.5.0...1.6.1) - 2019-09-06
 
 ## Fixed

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -130,7 +130,7 @@ class Chatkit
             $claims['su'] = true;
         }
 
-        $claims['exp'] = strtotime('+1 day', $now);
+        $claims['exp'] = $now + 24 * 60 * 60;
 
         $jwt = JWT::encode($claims, $split_key[1]);
         return [

--- a/src/Chatkit.php
+++ b/src/Chatkit.php
@@ -130,6 +130,7 @@ class Chatkit
             $claims['su'] = true;
         }
 
+        // not using functions such as `strtotime` as timezones/daylight savings are problematic
         $claims['exp'] = $now + 24 * 60 * 60;
 
         $jwt = JWT::encode($claims, $split_key[1]);

--- a/tests/GenerateTokenTest.php
+++ b/tests/GenerateTokenTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use Firebase\JWT\JWT;
+
+class GenerateTokenTest extends \Base {
+
+    public function testGenerateTokenGeneratesATokenWithoutAnyException()
+    {
+        $jwt = $this->chatkit->generateToken();
+        $this->assertArrayHasKey('token', $jwt);
+        $this->assertArrayHasKey('expires_in', $jwt);
+    }
+
+    public function testGenerateTokenGeneratesATokenWithTheNeededFields()
+    {
+        $split_key = explode(':', CHATKIT_INSTANCE_KEY);
+        $jwt_key = $split_key[1];
+
+        $token = $this->chatkit->generateToken()['token'];
+        $parsed_jwt = JWT::decode($token, $jwt_key, array('HS256'));
+
+        $this->assertObjectHasAttribute('instance', $parsed_jwt);
+        $this->assertObjectHasAttribute('iss', $parsed_jwt);
+        $this->assertObjectHasAttribute('iat', $parsed_jwt);
+        $this->assertObjectHasAttribute('exp', $parsed_jwt);
+
+        $this->assertLessThanOrEqual(time(), $parsed_jwt->iat);
+
+        // check exp is within 5s of the expected 24h window
+        $this->assertLessThanOrEqual(5, abs(time() + 24 * 60 * 60 - $parsed_jwt->exp));
+    }
+
+}


### PR DESCRIPTION
### Why?

We want to help customer reliably generate valid JWT tokens with the correct "exp" claim set.

----

- [x] CHANGELOG updated if relevant?
