### PR TITLE
Improve edit message api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/chatkit-server-php/compare/1.7.0...HEAD)
 
-## [1.8.0](https://github.com/pusher/chatkit-server-php/compare/1.7.0...1.8.0)
+## [1.9.0](https://github.com/pusher/chatkit-server-php/compare/1.7.0...1.9.0)
 
 ### Added
 
 - Adds message editing via `edit{Simple,Multipart,}Message`.
+
+## 1.8.0 Yanked
 
 ## [1.7.0](https://github.com/pusher/chatkit-server-php/compare/1.6.2...1.7.0)
 

--- a/src/Exceptions/UnexpectedArgumentException.php
+++ b/src/Exceptions/UnexpectedArgumentException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Chatkit\Exceptions;
+
+use Exception;
+
+class UnexpectedArgumentException extends Exception
+{
+}

--- a/tests/v2/MessageV2Test.php
+++ b/tests/v2/MessageV2Test.php
@@ -208,33 +208,31 @@ class MessageV2Test extends \Base {
     public function testEditMessageRaisesAnExceptionIfNoRoomIDIsProvided()
     {
         $this->expectException(Chatkit\Exceptions\MissingArgumentException::class);
-        $this->chatkit->editMessage([ 'sender_id' => 'ham', 'message_id' => 1, 'text' => 'hi' ]);
+        $this->chatkit->editMessage(null, 1, [ 'sender_id' => 'ham', 'text' => 'hi' ]);
     }
 
     public function testEditMessageRaisesAnExceptionIfNoMessageIDIsProvided()
     {
         $this->expectException(Chatkit\Exceptions\MissingArgumentException::class);
-        $this->chatkit->editMessage([ 'sender_id' => 'ham', 'room_id' => 'room', 'text' => 'hi' ]);
+        $this->chatkit->editMessage('room', null, [ 'sender_id' => 'ham', 'text' => 'hi' ]);
     }
 
     public function testEditMessageRaisesAnExceptionIfNoSenderIDIsProvided()
     {
         $this->expectException(Chatkit\Exceptions\MissingArgumentException::class);
-        $this->chatkit->editMessage([ 'room_id' => '123', 'message_id' => 1, 'text' => 'hi' ]);
+        $this->chatkit->editMessage('123', 1, [ 'text' => 'hi' ]);
     }
 
     public function testEditMessageRaisesAnExceptionIfNoTextIsProvided()
     {
         $this->expectException(Chatkit\Exceptions\MissingArgumentException::class);
-        $this->chatkit->editMessage([ 'sender_id' => 'ham', 'room_id' => '123', 'message_id' => 1]);
+        $this->chatkit->editMessage('123', 1, [ 'sender_id' => 'ham']);
     }
 
     public function testEditMessageRaisesAnExceptionIfNoResourceLinkIsProvidedForAMessageWithAnAttachment()
     {
         $this->expectException(Chatkit\Exceptions\MissingArgumentException::class);
-        $this->chatkit->editMessage([
-            'room_id' => '123',
-            'message_id' => 1,
+        $this->chatkit->editMessage('123', 1, [
             'sender_id' => 'ham',
             'text' => 'hi',
             'attachment' => [
@@ -246,9 +244,7 @@ class MessageV2Test extends \Base {
     public function testEditMessageRaisesAnExceptionIfNoTypeIsProvidedForAMessageWithAnAttachment()
     {
         $this->expectException(Chatkit\Exceptions\MissingArgumentException::class);
-        $this->chatkit->editMessage([
-            'room_id' => '123',
-            'message_id' => 1,
+        $this->chatkit->editMessage('123', 1, [
             'sender_id' => 'ham',
             'text' => 'hi',
             'attachment' => [
@@ -260,9 +256,7 @@ class MessageV2Test extends \Base {
     public function testEditMessageRaisesAnExceptionIfAnInvalidTypeIsProvidedForAMessageWithAnAttachment()
     {
         $this->expectException(Chatkit\Exceptions\MissingArgumentException::class);
-        $this->chatkit->editMessage([
-            'room_id' => '123',
-            'message_id' => 1,
+        $this->chatkit->editMessage('123', 1, [
             'sender_id' => 'ham',
             'text' => 'hi',
             'attachment' => [
@@ -295,10 +289,8 @@ class MessageV2Test extends \Base {
         $this->assertEquals($send_msg_res['status'], 201);
         $this->assertArrayHasKey('message_id', $send_msg_res['body']);
 
-        $edit_msg_res = $this->chatkit->editMessage([
+        $edit_msg_res = $this->chatkit->editMessage($room_res['body']['id'], $send_msg_res['body']['message_id'], [
             'sender_id' => $user_id,
-            'room_id' => $room_res['body']['id'],
-            'message_id' => $send_msg_res['body']['message_id'],
             'text' => 'edited-text'
         ]);
         $this->assertEquals($edit_msg_res['status'], 204);
@@ -331,10 +323,8 @@ class MessageV2Test extends \Base {
         $this->assertEquals($send_msg_res['status'], 201);
         $this->assertArrayHasKey('message_id', $send_msg_res['body']);
 
-        $edit_msg_res = $this->chatkit->editMessage([
+        $edit_msg_res = $this->chatkit->editMessage($room_res['body']['id'], $send_msg_res['body']['message_id'], [
             'sender_id' => $user_id,
-            'room_id' => $room_res['body']['id'],
-            'message_id' => $send_msg_res['body']['message_id'],
             'text' => 'edited-text',
             'attachment' => [
                 'resource_link' => 'https://placekitten.com/200/300',

--- a/tests/v5/MessageTest.php
+++ b/tests/v5/MessageTest.php
@@ -111,10 +111,8 @@ class MessageTest extends \Base {
         $this->assertEquals($send_msg_res['status'], 201);
         $this->assertArrayHasKey('message_id', $send_msg_res['body']);
 
-        $edit_msg_res = $this->chatkit->editMultipartMessage([
+        $edit_msg_res = $this->chatkit->editMultipartMessage($room_id, $send_msg_res['body']['message_id'], [
             'sender_id' => $user_id,
-            'room_id' => $room_id,
-            'message_id' => $send_msg_res['body']['message_id'],
             'parts' => $parts
         ]);
         $this->assertEquals($edit_msg_res['status'], 204);
@@ -131,24 +129,18 @@ class MessageTest extends \Base {
         ];
 
         $this->expectException(Chatkit\Exceptions\TypeMismatchException::class);
-        $this->chatkit->editMultipartMessage([ 'sender_id' => 'user_id',
-                                               'room_id' => 42,
-                                               'message_id' => 42,
+        $this->chatkit->editMultipartMessage(42, 42, [ 'sender_id' => 'user_id',
                                                'parts' => $good_parts
         ]);
 
         $this->expectException(Chatkit\Exceptions\TypeMismatchException::class);
-        $this->chatkit->editMultipartMessage([ 'sender_id' => 42,
-                                               'room_id' => 'room_id',
-                                               'message_id' => 42,
-                                               'parts' => $good_parts
+        $this->chatkit->editMultipartMessage('room_id', 42, [ 'sender_id' => 42,
+                                                              'parts' => $good_parts
         ]);
 
         $this->expectException(Chatkit\Exceptions\TypeMismatchException::class);
-        $this->chatkit->editMultipartMessage([ 'sender_id' => 'user_id',
-                                               'room_id' => 'room_id',
-                                               'message_id' => 42,
-                                               'parts' => $bad_parts
+        $this->chatkit->editMultipartMessage('room_id', 42, [ 'sender_id' => 'user_id',
+                                                              'parts' => $bad_parts
         ]);
     }
 
@@ -179,10 +171,8 @@ class MessageTest extends \Base {
         $this->assertEquals($send_msg_res['status'], 201);
         $this->assertArrayHasKey('message_id', $send_msg_res['body']);
 
-        $edit_msg_res = $this->chatkit->editMultipartMessage([
+        $edit_msg_res = $this->chatkit->editMultipartMessage($room_id, $send_msg_res['body']['message_id'], [
             'sender_id' => $user_id,
-            'room_id' => $room_id,
-            'message_id' => $send_msg_res['body']['message_id'],
             'parts' => $parts
         ]);
         $this->assertEquals($edit_msg_res['status'], 204);
@@ -201,10 +191,8 @@ class MessageTest extends \Base {
         $this->assertEquals($send_msg_res['status'], 201);
         $this->assertArrayHasKey('message_id', $send_msg_res['body']);
 
-        $edit_msg_res = $this->chatkit->editSimpleMessage([
+        $edit_msg_res = $this->chatkit->editSimpleMessage($room_id, $send_msg_res['body']['message_id'], [
             'sender_id' => $user_id,
-            'room_id' => $room_id,
-            'message_id' => $send_msg_res['body']['message_id'],
             'text' => 'testing'
         ]);
         $this->assertEquals($edit_msg_res['status'], 204);


### PR DESCRIPTION
Adjust editMessage api to clarify that room_id and message_id identify the message to edit by prefixing their options with `match_`.


----

- [x] CHANGELOG updated if relevant?
